### PR TITLE
fixed joining cluster issue between RabbitMq master node and cluster node

### DIFF
--- a/userdata.yml
+++ b/userdata.yml
@@ -4,22 +4,20 @@ packages:
   - wget
 
 runcmd:
-  - yum update -y
-  #- amazon-linux-extras install epel -y
-  #- yum install erlang -y
-  #- yum install rabbitmq-server -y
-  - wget https://github.com/rabbitmq/erlang-rpm/releases/download/v23.2.1/erlang-23.2.1-1.el7.x86_64.rpm
-  - yum localinstall erlang-23.2.1-1.el7.x86_64.rpm -y
-  - wget https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.10.0/rabbitmq-server-3.10.0-1.el8.noarch.rpm
-  - rpm -Uvh rabbitmq-server-3.10.0-1.el8.noarch.rpm
-  - systemctl enable --now rabbitmq-server.service
-  - rabbitmq-plugins enable rabbitmq_management
-  - systemctl enable rabbitmq-server.service
-  - systemctl start rabbitmq-server.service
-  - systemctl stop rabbitmq-server.service
-  - truncate -s 0 /var/lib/rabbitmq/.erlang.cookie
+  - echo "****************script starts here ******************"
+  - sudo hostnamectl set-hostname master
+  - sudo systemctl restart network
+  - export PRIVATE_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
+  - echo "$PRIVATE_IP master">/etc/hosts
+  - sudo yum update -y
+  - sudo amazon-linux-extras install epel -y
+  - curl -s https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
+  - curl -s https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
+  - sudo yum install rabbitmq-server erlang -y
+  - sudo systemctl enable --now rabbitmq-server.service
+  - sudo truncate -s 0 /var/lib/rabbitmq/.erlang.cookie
   - echo "XAIFUIBJAVHSEZOKOMHD" >> /var/lib/rabbitmq/.erlang.cookie
-  - systemctl start rabbitmq-server.service
+  - sudo systemctl restart rabbitmq-server.service
   - export USERNAME="$(aws ssm get-parameter --name /${environment_name}/rabbit/USERNAME --with-decryption --output text --query Parameter.Value --region ${region})"
   - export PASS="$(aws ssm get-parameter --name /${environment_name}/rabbit/PASSWORD --with-decryption --output text --query Parameter.Value --region ${region})"
   - sudo rabbitmqctl add_user "$USERNAME" "$PASS"
@@ -28,3 +26,4 @@ runcmd:
   - sleep 10s
   - sudo rabbitmq-plugins enable rabbitmq_management
   - sudo systemctl restart rabbitmq-server.service
+

--- a/worker.sh
+++ b/worker.sh
@@ -1,40 +1,20 @@
 #!/bin/bash
 
 sudo yum update -y
-# sudo yum install nc -y
-# sudo amazon-linux-extras install epel -y
-# sudo yum install erlang -y
-wget https://github.com/rabbitmq/erlang-rpm/releases/download/v23.2.1/erlang-23.2.1-1.el7.x86_64.rpm
-yum localinstall erlang-23.2.1-1.el7.x86_64.rpm -y
-wget https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.10.0/rabbitmq-server-3.10.0-1.el8.noarch.rpm	
-sudo rpm -Uvh rabbitmq-server-3.10.0-1.el8.noarch.rpm
+export MASTER_IP="$(aws ec2 describe-instances --filters "Name=tag:Name,Values=${Name}" "Name=instance-state-name,Values=running"  --query 'Reservations[*].Instances[*].{PrivateIP:PrivateIpAddress}' --output text --region ${region})"
+echo "$MASTER_IP master">/etc/hosts
+yum update -y
+sudo amazon-linux-extras install epel -y
+curl -s https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
+curl -s https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
+sudo yum install rabbitmq-server erlang -y
 systemctl enable --now rabbitmq-server.service
-sudo rabbitmqctl start_app
-sudo rabbitmqctl stop_app
 sudo truncate -s 0  /var/lib/rabbitmq/.erlang.cookie
 sudo echo "XAIFUIBJAVHSEZOKOMHD" >>  /var/lib/rabbitmq/.erlang.cookie
 sudo echo "erlang cookied added"
-
 sudo systemctl restart rabbitmq-server.service
-sudo rabbitmqctl start_app
 sudo rabbitmqctl stop_app
-export MASTER_IP="$(aws ec2 describe-instances --filters "Name=tag:Name,Values=${Name}" "Name=instance-state-name,Values=running"  --query 'Reservations[*].Instances[*].{PrivateIP:PrivateIpAddress}' --output text --region ${region})"
-echo "$MASTER_IP"
-yum install -y nc
+sudo rabbitmqctl reset && sudo rabbitmqctl join_cluster rabbit@master
 
-while [ $? -eq 0 ]
-do
-    nc -zv "$MASTER_IP" 4369
-    if [ $? -eq 0 ]; then
-    echo "Command Executed Successfully"
-    export FINAL="$(echo $MASTER_IP | sed 's/\./-/g')"
-    echo "$FINAL"
-    sudo rabbitmqctl join_cluster "rabbit@ip-$FINAL"
-    sudo rabbitmqctl start_app
-    sudo rabbitmq-plugins enable rabbitmq_management
-    sudo systemctl restart rabbitmq-server.service
-    break
-else
-    echo "Command Failed"
-fi
-done
+
+

--- a/worker.yml
+++ b/worker.yml
@@ -1,0 +1,20 @@
+#cloud-config
+
+runcmd:
+  - echo "****************script starts here ******************"
+  - sudo yum update -y
+  - export MASTER_IP="$(aws ec2 describe-instances --filters "Name=tag:Name,Values=${Name}" "Name=instance-state-name,Values=running"  --query 'Reservations[*].Instances[*].{PrivateIP:PrivateIpAddress}' --output text --region ${region})"
+  - echo "$MASTER_IP master">/etc/hosts
+  - sudo amazon-linux-extras install epel -y
+  - curl -s https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
+  - curl -s https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
+  - sudo yum install rabbitmq-server erlang -y
+  - systemctl enable --now rabbitmq-server.service
+  - sudo truncate -s 0 /var/lib/rabbitmq/.erlang.cookie
+  - sudo echo "XAIFUIBJAVHSEZOKOMHD" >> /var/lib/rabbitmq/.erlang.cookie
+  - sudo echo "erlang cookied added"
+  - sudo systemctl restart rabbitmq-server.service
+  - sudo rabbitmqctl stop_app
+  - sudo rabbitmqctl reset
+  - sleep 10  
+  - sudo rabbitmqctl join_cluster rabbit@master


### PR DESCRIPTION
## features updated

* Userdata converted to cloud-init
* Erlang and Rabbitmq is installing through package cloud script as mentioned in Rabbitmq's Webpage
  https://www.rabbitmq.com/install-rpm.html#packagecloud
* Joining workers to master node is done
*  Populating  /etc/hosts file  of worker and master instance for connection with master 