### PR TITLE
added a conndition to wait master node to be up before joining the worker node

### DIFF
--- a/worker.yml
+++ b/worker.yml
@@ -14,7 +14,8 @@ runcmd:
   - sudo echo "XAIFUIBJAVHSEZOKOMHD" >> /var/lib/rabbitmq/.erlang.cookie
   - sudo echo "erlang cookied added"
   - sudo systemctl restart rabbitmq-server.service
+  - until sudo rabbitmqctl -n rabbit@master cluster_status; do sleep 5; done  
   - sudo rabbitmqctl stop_app
   - sudo rabbitmqctl reset
-  - sleep 10  
   - sudo rabbitmqctl join_cluster rabbit@master
+  - sudo rabbitmqctl start_app


### PR DESCRIPTION
**feature added**

While joining cluster master node was not fully up so added a conditional loop to check if master node is up or not and then join the worker node to master node in rabbitmq cluster